### PR TITLE
Add funtion to save and restore the entire routing table to a disk file.

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -13,3 +13,5 @@ This module will connect to any Blackmagic Design VideoHub Device.
 * Route source to selected destination
 * Take (when enabled)
 * Clear (when enabled)
+* Write routes to a disk file
+* Read routes from a disk file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # companion-module-bmd-videohub
 See HELP.md and LICENSE
 
+**Changes in v1.3.0**
+- Added ability to read and write routing table to a disk file.
+- Added 'Return to previous Route' as a release action
 **Changes in v1.2.0**
 - Moved to split files structure for actions, feedback, presets, and variables.
 - **companion-module-bmd-multiview16 extends this module.**  Future changes require testing against both modules.

--- a/actions.js
+++ b/actions.js
@@ -12,6 +12,45 @@ module.exports = {
 	getActions() {
 		var actions = {};
 
+		actions['route_to_previous'] = {
+			label: 'Return to previous route',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Destination',
+					id: 'destination',
+					default: '0',
+					choices: this.CHOICES_OUTPUTS
+				}
+			]
+		};
+
+		actions['load_route_from_file'] = {
+			label: 'Load Routes File',
+			options: [
+								
+				{
+					type: 'textinput',
+					label: 'Source File',
+					id: 'source_file',
+					default: "C:\\VideoHub.txt"
+				}
+			]
+		};
+
+		actions['store_route_in_file'] = {
+			label: 'Save Routes File',
+			options: [
+								
+				{
+					type: 'textinput',
+					label: 'Destination File',
+					id: 'destination_file',
+					default: "C:\\VideoHub.txt"
+				}
+			]
+		};
+
 		actions['rename_destination'] = {
 			label: 'Rename destination',
 			options: [

--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
 var tcp = require('../../tcp');
 var instance_skel = require('../../instance_skel');
+var fs = require('fs');
 
 var instance_api  = require('./internalAPI');
 var actions       = require('./actions');
 var feedback      = require('./feedback');
 var presets       = require('./presets');
 var variables     = require('./variables');
+const { isNull }  = require('util');
+const { getOutput } = require('./internalAPI');
 
 var debug;
 var log;
+
 
 /**
  * Companion instance class for the Blackmagic VideoHub Routers.
@@ -16,10 +20,12 @@ var log;
  * !!! This class is being used by the bmd-multiview16 module, be careful !!!
  *
  * @extends instance_skel
- * @version 1.2.0
+ * @version 1.3.0
  * @since 1.0.0
  * @author William Viker <william@bitfocus.io>
  * @author Keith Rocheck <keith.rocheck@gmail.com>
+ * @author Peter Schuster
+ * @author Jim Amen <jim.amen50@gmail.com>
  */
 class instance extends instance_skel {
 
@@ -70,6 +76,7 @@ class instance extends instance_skel {
 		];
 
 		this.actions(); // export actions
+
 	}
 
 	/**
@@ -95,9 +102,79 @@ class instance extends instance_skel {
 	action(action) {
 		var cmd;
 		var opt = action.options;
+		var string = "";
+		var routes_text = [];
+		var data =[];  // String with route date that gets written to file
+		var routes = [];  // disk data parse helper
+		var dest_source = [];  // disk data parse helper
 
 		switch (action.action) {
+
+			case 'store_route_in_file':  // added ability to store routes to a file v1.3.0
+
+				string = "  : BMD uses zero based indexing when referencing source and destination so '0' in this file refernces port '1'.  You may add your own text here after the colon. \n";
+				string = "\nRouting history: \n"
+
+				// this information in the disk file is more for debug than anything else.  Its ignored on read
+				for (let index = 0; index < this.outputCount; index++) {
+					data[index] = index  + ' ' + this.getOutput(index).route;
+					string = string + index + "  " + this.getOutput(index).fallback + "\n"
+				}
+				try{
+					// use the blocking version of file write here.
+					fs.writeFileSync(opt.destination_file, data + string, 'utf8');
+					this.log('info',data.length + " Routes written to: " + opt.destination_file );
+				}
+				catch (e) {
+					this.log('error',"File Write Error: " + e.message);
+				}
+				break;
+
+			case 'load_route_from_file': // added ability to read routes from a file v1.3.0
+
+				try {
+					// use the blocking version of file read here. 
+					var data = fs.readFileSync(opt.source_file, 'utf8');
+					try{
+						routes_text= data.split(':');  // strip out unwanted text after the ':'
+						routes = routes_text[0].split(',');  // split routes into source - destination array
+						if((routes.length > 0) && (routes.length <= this.outputCount)) {      
+						    cmd = '';
+							for (let index = 0; index < routes.length; index++) {
+								dest_source = routes[index].split(' ');
+								if(isNaN(dest_source[0])) {
+									throw routes[index] + " - " + dest_source[0] + " is not a valid Router Destination ";
+								}
+								if(dest_source[0] < 0 || dest_source[0] > (this.outputCount - 1)) {
+									throw dest_source[0] + "  is an invalid destination.  Remember, Router is zero based when indexing ports.  Max Routes for this router = " + this.outputCount;
+								}
+								if(isNaN(dest_source[1])) {
+									throw routes[index] + " - " + dest_source[1] + " is not a valid Router Source ";
+								}
+								if(dest_source[1] < 0 || dest_source[1] > (this.outputCount - 1)) {
+									throw dest_source[1] + "  is an invalid source. Remember, Router is zero based when indexing ports.  Max Routes for this router = " +this.outputCount; 
+								}
+								cmd = cmd + "VIDEO OUTPUT ROUTING:\n" +  routes[index] + "\n\n";  // not sure if we need both \n here...
+							}
+						}
+						else {
+							throw "Invalid number of Routes: " + routes.length + ",";
+						}
+						this.log('info', routes.length + " Routes read from File: " + opt.source_file );
+					}
+					catch (err) {
+						this.log('error', err + " in File:" + opt.source_file);
+					}
+				}
+				catch(e) {
+					this.log('error',"File Read Error: " + e.message);
+				}
+				break;
+
 			case 'route':
+
+				var output = this.getOutput(parseInt(opt.destination));
+
 				if (parseInt(opt.destination) >= this.outputCount) {
 					cmd = "VIDEO MONITORING OUTPUT ROUTING:\n"+(parseInt(opt.destination)-this.outputCount)+" "+opt.source+"\n\n";
 				}
@@ -105,13 +182,45 @@ class instance extends instance_skel {
 					cmd = "VIDEO OUTPUT ROUTING:\n"+opt.destination+" "+opt.source+"\n\n";
 				}
 				break;
+
+			case 'route_to_previous':
+
+				var output = this.getOutput(parseInt(opt.destination));
+				var fallbackpop = -1;
+
+				if(output !== undefined){
+					fallbackpop = output.fallback.pop();  // The current route (i.e what the hardware is acctually set to)
+														  // has already been pushed onto the stack at "updateRouting" so to 
+														  // get to the last route we have to first pop this one off
+					fallbackpop = output.fallback.pop();  // This now, is the route to fallback to
+					
+					if(output.fallback.length < 1 ){
+						output.fallback.push(-1);
+					}
+				}
+				if (output !== undefined && fallbackpop >= 0) {
+
+					if (parseInt(opt.destination) >= this.outputCount) {
+						cmd = "VIDEO MONITORING OUTPUT ROUTING:\n"+(parseInt(opt.destination)-this.outputCount) + " " + fallbackpop + "\n\n";
+					}
+					else {
+						cmd = "VIDEO OUTPUT ROUTING:\n"+opt.destination + " " + fallbackpop + "\n\n";
+					}
+				}
+				break;
+
 			case 'route_serial':
+
 				cmd = "SERIAL PORT ROUTING:\n"+opt.destination+" "+opt.source+"\n\n";
 				break;
+
 			case 'rename_source':
+
 				cmd = "INPUT LABELS:\n"+opt.source+" "+opt.label+"\n\n";
 				break;
+
 			case 'rename_destination':
+
 				if (parseInt(opt.destination) >= this.outputCount) {
 					cmd = "MONITORING OUTPUT LABELS:\n"+(parseInt(opt.destination)-this.outputCount)+" "+opt.label+"\n\n";
 				}
@@ -119,16 +228,22 @@ class instance extends instance_skel {
 					cmd = "OUTPUT LABELS:\n"+opt.destination+" "+opt.label+"\n\n";
 				}
 				break;
+
 			case 'rename_serial':
+			
 				cmd = "SERIAL PORT LABELS:\n"+opt.serial+" "+opt.label+"\n\n";
 				break;
+
 			case 'select_destination':
-				this.selected = parseInt(opt.destination);
+
+			this.selected = parseInt(opt.destination);
 				this.checkFeedbacks('selected_destination');
 				this.checkFeedbacks('take_tally_source');
 				this.checkFeedbacks('selected_source');
 				break;
+
 			case 'route_source':
+
 				if (this.selected >= this.outputCount) {
 					if (this.config.take === true) {
 						this.queue = "VIDEO MONITORING OUTPUT ROUTING:\n"+(this.selected-this.outputCount)+" "+opt.source+"\n\n";
@@ -158,6 +273,7 @@ class instance extends instance_skel {
 					}
 				}
 				break;
+
 			case 'take':
 				cmd = this.queue;
 				this.queue = '';
@@ -167,6 +283,8 @@ class instance extends instance_skel {
 				this.checkFeedbacks('take_tally_source');
 				this.checkFeedbacks('take_tally_dest');
 				this.checkFeedbacks('take_tally_route');
+				break;  // why no break here originally? jla
+
 			case 'clear':
 				this.queue = '';
 				this.queuedDest = -1;
@@ -175,15 +293,21 @@ class instance extends instance_skel {
 				this.checkFeedbacks('take_tally_source');
 				this.checkFeedbacks('take_tally_dest');
 				this.checkFeedbacks('take_tally_route');
+				break;  // why no break here originally?   jla
 		}
 
 		if (cmd !== undefined) {
-
+			// do the work of sending data to Videohub right here!  jla
 			if (this.socket !== undefined && this.socket.connected) {
-				this.socket.send(cmd);
+				try {
+					this.socket.send(cmd);
+				} catch (error) {
+					this.log('error',"TCP error " + error.message);
+				}
 			}
 			else {
-				this.debug('Socket not connected :(');
+				this.log('error',"Socket not connected ");   /// changed to an 'error' instead of debug
+				init_tcp();                                  /// what the heck, lets try to reinitialize the tcp stack
 			}
 		}
 	}
@@ -225,7 +349,7 @@ class instance extends instance_skel {
 				id: 'info',
 				width: 12,
 				label: 'Information',
-				value: 'This counts below will automatically populate from the device upon connection, however, can be set manually for offline programming.'
+				value: 'The counts below will automatically populate from the device upon connection, however, they can be set manually for offline programming.'
 			},
 			{
 				type: 'number',
@@ -409,8 +533,7 @@ class instance extends instance_skel {
 			this.initPresets();
 		}
 		else if (key.match(/(VIDEO OUTPUT|VIDEO MONITORING OUTPUT|SERIAL PORT) ROUTING/)) {
-			this.updateRouting(key,data);
-
+			this.updateRouting(key,data); 
 			this.checkFeedbacks('input_bg');
 			this.checkFeedbacks('selected_source');
 		}

--- a/internalAPI.js
+++ b/internalAPI.js
@@ -8,7 +8,6 @@ module.exports = {
 	 * @access protected
 	 * @since 1.1.0
 	 */
-
 	getInput(id) {
 
 		if (this.inputs[id] === undefined) {
@@ -189,9 +188,8 @@ module.exports = {
 		}
 	},
 
-
 	/**
-	 * INTERNAL: Updates routing table based on data From the Videohub
+	 * INTERNAL: Updates Companion's routing table based on data sent from the Videohub
 	 *
 	 * @param {string} labeltype - the command/data type being passed
 	 * @param {Object} object - the collected data
@@ -215,7 +213,7 @@ module.exports = {
 					if(output.fallback.length > 20){
 						output.fallback = output.fallback.slice(2);
 					}
-	                output.fallback.push(src);  // push the route returned from the hardware into the fallback route 
+					output.fallback.push(src);  // push the route returned from the hardware into the fallback route 
 					output.route = src;         // now we set the route in the container to the new value
 					this.setVariable('output_' + (dest+1) + '_input',  this.getInput(src).name);
 					break;

--- a/internalAPI.js
+++ b/internalAPI.js
@@ -8,6 +8,7 @@ module.exports = {
 	 * @access protected
 	 * @since 1.1.0
 	 */
+
 	getInput(id) {
 
 		if (this.inputs[id] === undefined) {
@@ -38,10 +39,10 @@ module.exports = {
 				name:       'Output ' + (id+1),
 				route:      id,
 				status:     'BNC',
-				lock:       'U'
+				lock:       'U',
+				fallback: 	[-1]
 			};
 		}
-
 		return this.outputs[id];
 	},
 
@@ -188,8 +189,9 @@ module.exports = {
 		}
 	},
 
+
 	/**
-	 * INTERNAL: Updates routing table based on data from the Videohub
+	 * INTERNAL: Updates routing table based on data From the Videohub
 	 *
 	 * @param {string} labeltype - the command/data type being passed
 	 * @param {Object} object - the collected data
@@ -208,7 +210,13 @@ module.exports = {
 				case 'VIDEO MONITORING OUTPUT ROUTING':
 					dest = dest + this.outputCount;
 				case 'VIDEO OUTPUT ROUTING':
-					this.getOutput(dest).route = src;
+					var output = this.getOutput(parseInt(dest));
+					// Lets not let the fallback array grow without bounds. is 20 enough?
+					if(output.fallback.length > 20){
+						output.fallback = output.fallback.slice(2);
+					}
+	                output.fallback.push(src);  // push the route returned from the hardware into the fallback route 
+					output.route = src;         // now we set the route in the container to the new value
 					this.setVariable('output_' + (dest+1) + '_input',  this.getInput(src).name);
 					break;
 				case 'SERIAL PORT ROUTING':

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"videohub"
 	],
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"api_version": "1.0.0",
 	"keywords": [ "Matrix" ],
 	"manufacturer": "Blackmagic Design",

--- a/presets.js
+++ b/presets.js
@@ -177,6 +177,47 @@ module.exports = {
 						}
 					]
 				});
+
+				presets.push({
+					category: 'Output ' + (out+1) + ' (momentary)',
+					label: 'Output ' + (out+1) + ' button for ' + this.getInput(i).name + ' with route back',
+					bank: {
+						style: 'text',
+						text: '$(videohub:input_' + (i+1) + ') (mom.)',
+						size: '18',
+						color: this.rgb(255,255,255),
+						bgcolor: this.rgb(0,0,0)
+					},
+					feedbacks: [
+						{
+							type: 'input_bg',
+							options: {
+								bg: this.rgb(255,255,0),
+								fg: this.rgb(0,0,0),
+								input: i,
+								output: out
+							}
+						}
+					],
+					actions: [
+						{
+							action: 'route',
+							options: {
+								source: i,
+								destination: out
+							}
+						}
+					],
+					release_actions: [
+						{
+							action: 'route_to_previous',
+							options: {
+								destination: out
+							}
+						}
+					]
+				});
+
 			}
 		}
 

--- a/variables.js
+++ b/variables.js
@@ -1,5 +1,5 @@
 module.exports = {
-
+	
 	/**
 	 * INTERNAL: initialize variables.
 	 *


### PR DESCRIPTION
Routing information is stored as text, (easy to read).  Useful to easily change the base configurations between two different use cases (mine is college baseball and pro baseball).  Also incorporated the "return-to-previous-route" from peschuster.  This function allows a destination to revert to whatever its last source was before it was changed.  Added a 20 value stack to this functionality.  Also modified it so that changes made from other software (and maybe even the front panel, though I can't test that)  can be returned to.  Can be used as a 'key-up' action to make a key "press to show a new route then on release but it back the way it was".  I developed this on Windows and don't have Mac or Linux to test.